### PR TITLE
Warning when &PK not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ cargo run --account=$ETH1_WITHDRAWAL_ADDRESS --threshold=$MIN_WITHDRAW
 
 ```shell
 docker build -t gbc-claim
-docker run --rm -e PK=$PK gbc-claim --account=$ETH1_WITHDRWAW_ADDRESS --threshold=$MIN_WITHDRAW
+docker run --rm -e PK=$PK gbc-claim --account=$ETH1_WITHDRAWAL_ADDRESS --threshold=$MIN_WITHDRAW
 ```
 


### PR DESCRIPTION
Instead of crashing and requiring PK - one may just want to read the balance. This approach seems better than panic!

```
➜ cargo run -- --account=$ETH1_WITHDRAW_ADDRESS --threshold=1

⚠️  PK not set — running in read-only mode (cannot claim)
⚠️  Reward (7.86681108125) is above threshold, but no PK is configured.
🔒 Read-only mode: cannot send claim transaction.

➜  cargo run -- --account=$ETH1_WITHDRAW_ADDRESS --threshold=100000000000000000000

⚠️  PK not set — running in read-only mode (cannot claim)
reward balance 7.86681108125 below threshold of 100 GNO
```